### PR TITLE
Reverting to the version of the jekyll gem to use it with the gem github-pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
+
+# ruby file: ".ruby-version"
+
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
@@ -7,7 +12,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll"
+gem "jekyll", "~> 3.9.4"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima"
 gem "minimal-mistakes-jekyll"

--- a/_config.yml
+++ b/_config.yml
@@ -31,7 +31,7 @@ github_username:  jekyll
 
 # Build settings
 remote_theme: "mmistakes/minimal-mistakes"
-minimal_mistakes_skin: "default" # "default" "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin: "aqua" # "default" "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Archives
 #  Type


### PR DESCRIPTION
Reverting to the version 3.9.4 of the jekyll gem to make it compatible with the gem github-pages and updating the colour of the theme