### PR TITLE
Adding a subpath and a base hostname for the blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,8 +24,8 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/jekyll-blog" # the subpath of your site, e.g. /blog
+url: "https://sk2108.github.io/" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 


### PR DESCRIPTION
This should fix the following issue: GitHub Pages does not render the CSS of the site.